### PR TITLE
fix: override whatwg-url version to prevent punycode warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 import { Command, Option } from 'commander';
 import { fileTypeFromBuffer } from 'file-type';
-import { URL } from 'whatwg-url';
 import fs from 'fs';
 import OpenAI from 'openai';
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "commander": "^9.0.0",
     "file-type": "^19.0.0",
-    "openai": "^4.28.0",
-    "whatwg-url": "^14.0.0"
+    "openai": "^4.28.0"
+  },
+  "overrides": {
+    "whatwg-url": "13.0.0"
   }
 }


### PR DESCRIPTION
The openai package transitively depends on an outdated version of whatwg-url, which causes nodejs to print a deprecation warning for punycode when running the vision tool. This will be fixed when openai resolves https://github.com/openai/openai-node/pull/392. Until then, override the version of whatwg-url in order to prevent the deprecation warning.

See https://github.com/openai/openai-node/issues/527#issuecomment-1823471697 for details on this stopgap.